### PR TITLE
Add hash-forged TCG React app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+dist
+.DS_Store

--- a/crypto-cards/index.html
+++ b/crypto-cards/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <title>Magic Crypto Cards</title>
+  </head>
+  <body class="bg-neutral-950">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/crypto-cards/package.json
+++ b/crypto-cards/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "crypto-cards",
+  "private": true,
+  "version": "0.2.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "crypto-js": "^4.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.12",
+    "vite": "^5.4.8"
+  }
+}

--- a/crypto-cards/postcss.config.js
+++ b/crypto-cards/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/crypto-cards/src/App.jsx
+++ b/crypto-cards/src/App.jsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useRef, useState } from "react";
+import CryptoJS from "crypto-js";
+import Card from "./Card.jsx";
+import { hashArtDataUrl, pickColorsFromHash, titleFromHash } from "./hashArt.js";
+
+const RARITIES = ["Common", "Rare", "Epic", "Mythic"];
+const ABILITIES = [
+  "Hash Surge",
+  "Block Forged",
+  "Nonce Shift",
+  "Genesis Echo",
+  "Merkle Bloom",
+  "Satoshi’s Whim",
+  "Patoshi Pulse",
+  "Ordinals Twist",
+];
+
+export default function App() {
+  const [input, setInput] = useState("");
+  const [cards, setCards] = useState([]);
+  const fileRef = useRef(null);
+
+  // load collection
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("cards_v2")) || [];
+    setCards(stored);
+  }, []);
+
+  const save = (next) => {
+    setCards(next);
+    localStorage.setItem("cards_v2", JSON.stringify(next));
+  };
+
+  const mint = () => {
+    if (!input.trim()) return;
+    const raw = input.trim();
+
+    const hash = CryptoJS.SHA256(raw).toString();
+    const id = hash;
+
+    // If card exists, focus it rather than duplicate
+    const i = cards.findIndex((c) => c.id === id);
+    if (i >= 0) {
+      const el = document.getElementById(`card-${id}`);
+      if (el) {
+        el.classList.remove("animate-pulse");
+        void el.offsetWidth;
+        el.classList.add("animate-pulse");
+        setTimeout(() => el.classList.remove("animate-pulse"), 600);
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      setInput("");
+      return;
+    }
+
+    // Attribute slices
+    // Weighted rarity: Common 60%, Rare 25%, Epic 10%, Mythic 5%
+    const rarityRoll = parseInt(hash.slice(0, 2), 16) / 255;
+    let rarity;
+    if (rarityRoll < 0.6) rarity = "Common";
+    else if (rarityRoll < 0.85) rarity = "Rare";
+    else if (rarityRoll < 0.95) rarity = "Epic";
+    else rarity = "Mythic";
+
+    const power = (parseInt(hash.slice(2, 4), 16) % 10) + 1;
+    const defense = (parseInt(hash.slice(4, 6), 16) % 10) + 1;
+    const ability = ABILITIES[parseInt(hash.slice(6, 8), 16) % ABILITIES.length];
+
+    const palette = pickColorsFromHash(hash);
+    const artDataUrl = hashArtDataUrl(hash, { width: 480, height: 672, palette });
+
+    const card = {
+      id,
+      name: titleFromHash(hash),
+      subtitle: `Genesis ${hash.slice(0, 6).toUpperCase()}`,
+      hash,
+      rarity,
+      power,
+      defense,
+      ability,
+      palette,
+      artDataUrl,
+      createdAt: Date.now(),
+      source: raw,
+    };
+
+    save([card, ...cards]);
+    setInput("");
+  };
+
+  const remove = (id) => {
+    save(cards.filter((c) => c.id !== id));
+  };
+
+  const clearAll = () => {
+    if (!confirm("Clear your entire collection?")) return;
+    save([]);
+  };
+
+  const doExport = () => {
+    const blob = new Blob([JSON.stringify(cards, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = Object.assign(document.createElement("a"), {
+      href: url,
+      download: "crypto-cards-export.json",
+    });
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const doImportClick = () => fileRef.current?.click();
+
+  const doImportFile = async (e) => {
+    const f = e.target.files?.[0];
+    e.target.value = "";
+    if (!f) return;
+    try {
+      const text = await f.text();
+      const incoming = JSON.parse(text);
+      if (!Array.isArray(incoming)) throw new Error("Invalid file");
+      const map = new Map(cards.map((c) => [c.id, c]));
+      incoming.forEach((c) => map.set(c.id, c));
+      save(Array.from(map.values()).sort((a, b) => b.createdAt - a.createdAt));
+    } catch (err) {
+      alert("Import failed: " + err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="sticky top-0 backdrop-blur bg-neutral-950/70 border-b border-white/10 z-20">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-4">
+          <h1 className="text-2xl md:text-3xl font-black tracking-tight select-none">
+            ⚡ Magic Crypto Cards
+          </h1>
+          <span className="ml-auto hidden sm:inline text-xs text-white/60 select-none">
+            Deterministic hash-forged trading cards
+          </span>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 py-8 flex-grow">
+        <div className="flex flex-col md:flex-row items-stretch md:items-center gap-3 mb-8">
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Enter any text (mock key, phrase, etc.)"
+            className="px-4 py-3 rounded-xl bg-white text-black w-full md:w-[520px] shadow-inner focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            aria-label="Input text to generate card"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") mint();
+            }}
+          />
+          <button
+            onClick={mint}
+            className="bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700 px-5 py-3 rounded-xl font-bold shadow-lg transition-colors"
+            aria-label="Generate card"
+            type="button"
+          >
+            Generate
+          </button>
+
+          <div className="flex gap-2 md:ml-auto flex-wrap">
+            <button
+              onClick={doExport}
+              className="px-4 py-3 rounded-xl border border-white/15 hover:bg-white/5 transition-colors whitespace-nowrap"
+              title="Export your collection to JSON"
+              type="button"
+            >
+              Export JSON
+            </button>
+            <button
+              onClick={doImportClick}
+              className="px-4 py-3 rounded-xl border border-white/15 hover:bg-white/5 transition-colors whitespace-nowrap"
+              title="Import a previously exported JSON"
+              type="button"
+            >
+              Import JSON
+            </button>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="application/json"
+              className="hidden"
+              onChange={doImportFile}
+              aria-hidden="true"
+              tabIndex={-1}
+            />
+            <button
+              onClick={clearAll}
+              className="px-4 py-3 rounded-xl border border-rose-500/40 text-rose-300 hover:bg-rose-500/10 transition-colors whitespace-nowrap"
+              title="Clear all cards"
+              type="button"
+            >
+              Clear All
+            </button>
+          </div>
+        </div>
+
+        {cards.length === 0 ? (
+          <p className="text-white/60 max-w-xl leading-relaxed">
+            No cards yet—mint one with any text. The art, name, stats and ability
+            are all derived from the SHA-256 hash of your input.
+          </p>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 justify-center">
+            {cards.map((c) => (
+              <Card key={c.id} id={`card-${c.id}`} card={c} onDelete={() => remove(c.id)} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <footer className="max-w-7xl mx-auto px-4 py-10 text-sm text-white/50 select-none">
+        <p>
+          Deterministic generator • Local-only • No network calls • Your data stays
+          in your browser (localStorage).
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/crypto-cards/src/Card.jsx
+++ b/crypto-cards/src/Card.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+import clsx from "clsx";
+
+const foilClass =
+  "before:absolute before:inset-0 before:rounded-[18px] before:bg-[conic-gradient(from_180deg,transparent,rgba(255,255,255,.05),transparent_30%)] before:mix-blend-overlay before:pointer-events-none";
+
+export default function Card({ card, onDelete, id }) {
+  const { name, subtitle, rarity, power, defense, ability, palette, artDataUrl, hash } = card;
+
+  const rim =
+    rarity === "Mythic"
+      ? "from-amber-400 via-fuchsia-400 to-cyan-400"
+      : rarity === "Epic"
+      ? "from-violet-400 to-indigo-400"
+      : rarity === "Rare"
+      ? "from-sky-400 to-emerald-400"
+      : "from-zinc-300 to-zinc-500";
+
+  const gem =
+    rarity === "Mythic"
+      ? "bg-gradient-to-br from-amber-300 to-pink-400"
+      : rarity === "Epic"
+      ? "bg-gradient-to-br from-violet-300 to-indigo-400"
+      : rarity === "Rare"
+      ? "bg-gradient-to-br from-sky-300 to-emerald-400"
+      : "bg-gradient-to-br from-zinc-200 to-zinc-400";
+
+  return (
+    <div
+      id={id}
+      className={clsx(
+        "relative w-[300px] h-[420px] rounded-2xl p-[2px] bg-gradient-to-br",
+        rim,
+        "shadow-[0_8px_40px_rgba(0,0,0,0.45)]"
+      )}
+    >
+      <div
+        className={clsx(
+          "relative h-full rounded-[18px] overflow-hidden bg-neutral-900 border border-white/10",
+          rarity === "Mythic" && foilClass
+        )}
+      >
+        <div className="h-[60%] w-full relative">
+          <img
+            src={artDataUrl}
+            alt={`Procedural artwork for card named ${name} with rarity ${rarity}`}
+            className="absolute inset-0 w-full h-full object-cover"
+            decoding="async"
+            loading="lazy"
+          />
+          <div
+            className="absolute inset-0 mix-blend-multiply pointer-events-none"
+            style={{
+              background:
+                "radial-gradient(60% 60% at 50% 40%, rgba(0,0,0,0) 30%, rgba(0,0,0,.35) 100%)",
+            }}
+          />
+          <div className="absolute top-2 right-2">
+            <div className={clsx("w-8 h-8 rounded-full border border-white/30", gem)} />
+          </div>
+        </div>
+
+        <div className="p-3 flex flex-col gap-1 h-[40%]">
+          <div className="flex items-baseline justify-between">
+            <h2 className="font-black tracking-tight text-lg leading-5 truncate" title={name}>
+              {name}
+            </h2>
+            <span className="text-xs px-2 py-0.5 rounded-full bg-white/10 border border-white/10 select-none">
+              {rarity}
+            </span>
+          </div>
+          <div className="text-[11px] text-white/60 truncate" title={subtitle}>
+            {subtitle}
+          </div>
+
+          <div className="mt-2 text-sm">
+            <div className="italic text-white/80 truncate" title={`Ability: ${ability}`}>
+              Ability: {ability}
+            </div>
+          </div>
+
+          <div className="mt-auto flex items-center justify-between">
+            <div className="flex gap-2">
+              <Pip label="POW" value={power} />
+              <Pip label="DEF" value={defense} />
+            </div>
+            <button
+              onClick={onDelete}
+              className="text-xs px-2 py-1 rounded-md bg-white/5 hover:bg-white/10 border border-white/10 transition-colors"
+              title="Delete card"
+              aria-label={`Delete card ${name}`}
+              type="button"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+
+        <div
+          className="pointer-events-none absolute -inset-2 rounded-[22px] blur-2xl opacity-20"
+          style={{
+            background: `radial-gradient(60% 60% at 50% 0%, ${palette[0]} 0%, transparent 60%), radial-gradient(50% 50% at 90% 10%, ${palette[1]} 0%, transparent 50%), radial-gradient(40% 40% at 10% 20%, ${palette[2]} 0%, transparent 40%)`,
+          }}
+        />
+      </div>
+
+      <div
+        className="absolute -bottom-7 left-0 text-[10px] text-white/35 w-full truncate select-text"
+        title={`Card hash: ${hash}`}
+      >
+        #{hash.slice(0, 24)}
+      </div>
+    </div>
+  );
+}
+
+function Pip({ label, value }) {
+  return (
+    <div className="px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs select-none">
+      <span className="text-white/60 mr-1">{label}</span>
+      <span className="font-bold tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/crypto-cards/src/hashArt.js
+++ b/crypto-cards/src/hashArt.js
@@ -1,0 +1,148 @@
+function makePRNG(hex) {
+  let seed = parseInt(hex.slice(0, 8), 16) || 0x12345678;
+  return function rand() {
+    seed ^= seed << 13;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5;
+    return (seed >>> 0) / 0xffffffff;
+  };
+}
+
+export function pickColorsFromHash(hash) {
+  const r = makePRNG(hash);
+  const h1 = Math.floor(r() * 360);
+  const h2 = (h1 + 120 + Math.floor(r() * 30) - 15) % 360;
+  const h3 = (h1 + 240 + Math.floor(r() * 30) - 15) % 360;
+  const s1 = 55 + Math.floor(r() * 35);
+  const s2 = 55 + Math.floor(r() * 35);
+  const s3 = 55 + Math.floor(r() * 35);
+  const l1 = 45 + Math.floor(r() * 10);
+  const l2 = 45 + Math.floor(r() * 10);
+  const l3 = 45 + Math.floor(r() * 10);
+  return [
+    `hsl(${h1}deg ${s1}% ${l1}%)`,
+    `hsl(${h2}deg ${s2}% ${l2}%)`,
+    `hsl(${h3}deg ${s3}% ${l3}%)`,
+  ];
+}
+
+export function titleFromHash(hash) {
+  const nouns = [
+    "Cipher",
+    "Relic",
+    "Sigil",
+    "Obelisk",
+    "Shard",
+    "Beacon",
+    "Bloom",
+    "Warden",
+    "Seraph",
+    "Rift",
+    "Spire",
+    "Helix",
+    "Grail",
+    "Totem",
+    "Eclipse",
+    "Nova",
+    "Catalyst",
+    "Vector",
+  ];
+  const adjs = [
+    "Genesis",
+    "Abyssal",
+    "Volt",
+    "Mythic",
+    "Glacial",
+    "Solar",
+    "Quantum",
+    "Echoing",
+    "Fractal",
+    "Nebular",
+    "Prismatic",
+  ];
+  const i = parseInt(hash.slice(8, 12), 16);
+  const j = parseInt(hash.slice(12, 16), 16);
+  return `${adjs[i % adjs.length]} ${nouns[j % nouns.length]}`;
+}
+
+export function hashArtDataUrl(hash, { width = 480, height = 672, palette } = {}) {
+  const cnv = document.createElement("canvas");
+  cnv.width = width;
+  cnv.height = height;
+  const ctx = cnv.getContext("2d");
+  const rnd = makePRNG(hash);
+  const [c1, c2, c3] = palette || pickColorsFromHash(hash);
+
+  const g = ctx.createLinearGradient(0, 0, width, height);
+  g.addColorStop(0, c1);
+  g.addColorStop(0.5, c2);
+  g.addColorStop(1, c3);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, width, height);
+
+  const img = ctx.createImageData(width, height);
+  const data = img.data;
+
+  const fx = 0.004 + rnd() * 0.01;
+  const fy = 0.004 + rnd() * 0.01;
+  const fz = 0.004 + rnd() * 0.01;
+  const p1 = rnd() * Math.PI * 2;
+  const p2 = rnd() * Math.PI * 2;
+  const p3 = rnd() * Math.PI * 2;
+
+  const rgb1 = hslToRgb(c1);
+  const rgb2 = hslToRgb(c2);
+  const rgb3 = hslToRgb(c3);
+
+  for (let y = 0; y < height; y++) {
+    const sy = Math.sin(y * fy + p2);
+    const sz = Math.sin(y * fz + p3);
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const s = Math.sin(x * fx + p1) + sy + sz;
+      const t = (s + 3) / 6;
+      const r = lerp3(rgb1[0], rgb2[0], rgb3[0], t);
+      const g = lerp3(rgb1[1], rgb2[1], rgb3[1], t);
+      const b = lerp3(rgb1[2], rgb2[2], rgb3[2], t);
+      data[i + 0] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+      data[i + 3] = 255;
+    }
+  }
+  ctx.globalAlpha = 0.35;
+  ctx.putImageData(img, 0, 0);
+  ctx.globalAlpha = 1;
+
+  const vg = ctx.createRadialGradient(
+    width / 2,
+    height * 0.45,
+    Math.min(width, height) * 0.1,
+    width / 2,
+    height / 2,
+    Math.max(width, height) * 0.75
+  );
+  vg.addColorStop(0, "rgba(0,0,0,0)");
+  vg.addColorStop(1, "rgba(0,0,0,0.45)");
+  ctx.fillStyle = vg;
+  ctx.fillRect(0, 0, width, height);
+
+  return cnv.toDataURL("image/png");
+}
+
+function lerp(a, b, t) {
+  return Math.round(a + (b - a) * t);
+}
+
+function lerp3(a, b, c, t) {
+  return t < 0.5 ? lerp(a, b, t * 2) : lerp(b, c, (t - 0.5) * 2);
+}
+
+function hslToRgb(hsl) {
+  const c = document.createElement("canvas");
+  const x = c.getContext("2d");
+  x.fillStyle = hsl;
+  x.fillRect(0, 0, 1, 1);
+  const [r, g, b] = x.getImageData(0, 0, 1, 1).data;
+  return [r, g, b];
+}

--- a/crypto-cards/src/index.css
+++ b/crypto-cards/src/index.css
@@ -1,0 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --ring: 0 0% 100%;
+  }
+  body {
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+      "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, "Apple Color Emoji",
+      "Segoe UI Emoji";
+  }
+}

--- a/crypto-cards/src/main.jsx
+++ b/crypto-cards/src/main.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/crypto-cards/tailwind.config.js
+++ b/crypto-cards/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx}"],
+  theme: {
+    extend: {
+      animation: {
+        pulse: "pulse 0.6s ease-in-out",
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add React-based **Magic Crypto Cards** generator with SHA-256-driven stats and deterministic artwork
- include Tailwind/clsx styling for foil rims, rarity gems, and export/import tools
- ignore build artifacts with a repo-wide `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c10c710544832596cf8222655ab950