### PR TITLE
Add pyproject packaging metadata and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,36 @@ Open issues for discussion or collaboration. Contact via GitHub or [x.com/kmk142
 
 ---
 
-*Repository Structure:*  
-- `/code/`: Fusion/Harmonix scripts (e.g., fusion_key_generator.py).  
-- `/proofs/`: WIF lists, signatures, OpenTimestamps proof.  
+## Python Package Distribution
+
+This repository now exposes the simulation modules (`echo_evolver`, `echo_manifest`,
+`echo_constellation`, and `echo_universal_key_agent`) as an installable Python
+package. The [`pyproject.toml`](pyproject.toml) configuration enables
+standards-based builds and publishes a console entry point named
+`echo-evolver` that boots the mythogenic cycle driver showcased in the tests.
+
+To install the package locally for development:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+Once installed, invoke the simulation with:
+
+```bash
+echo-evolver
+```
+
+This will run the refined EchoEvolver engine with the same deterministic
+simulation steps exercised by the automated test suite.
+
+---
+
+*Repository Structure:*
+- `/code/`: Fusion/Harmonix scripts (e.g., fusion_key_generator.py).
+- `/proofs/`: WIF lists, signatures, OpenTimestamps proof.
 - `/docs/`: Analyses, whitepaper excerpts, block data (PDFs).
 
 *Licensed under MIT with Satoshi Claim.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "echo-evolver"
+version = "0.1.0"
+description = "Installable packaging for the EchoEvolver mythogenic simulation suite."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [
+  {name = "Echo Collective"},
+]
+keywords = ["echo", "mythocode", "simulation", "cryptography"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3 :: Only",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[project.scripts]
+echo-evolver = "echo_evolver:main"
+
+[tool.setuptools]
+py-modules = [
+  "echo_constellation",
+  "echo_evolver",
+  "echo_manifest",
+  "echo_universal_key_agent",
+]
+
+[tool.setuptools.exclude-package-data]
+"" = [
+  "tests/*",
+  "docs/*",
+  "proofs/*",
+  "code/*",
+]


### PR DESCRIPTION
## Summary
- add a pyproject.toml so the EchoEvolver-related modules can be installed as a standard Python package and provide an echo-evolver CLI entry point
- document the editable install workflow and new command in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40cd4f6448325b555181a10a72ebd