### PR TITLE
Add EllegatoAI conversational engine

### DIFF
--- a/code/__init__.py
+++ b/code/__init__.py
@@ -1,6 +1,12 @@
 """Internal python modules used by the Echo toolkit test-suite."""
 
+from .ellegato_ai import EllegatoAI
 from .harmonic_cognition import HarmonicResponse, HarmonicSettings, harmonic_cognition
 
-__all__ = ["HarmonicResponse", "HarmonicSettings", "harmonic_cognition"]
+__all__ = [
+    "EllegatoAI",
+    "HarmonicResponse",
+    "HarmonicSettings",
+    "harmonic_cognition",
+]
 

--- a/code/ellegato_ai.py
+++ b/code/ellegato_ai.py
@@ -1,0 +1,127 @@
+"""Conversational assistant that turns prompts into lyrical responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+def _normalise_preferences(preferences: Iterable[str] | str | None) -> List[str]:
+    """Return a list of musical preferences from flexible input values."""
+
+    if preferences is None:
+        return []
+    if isinstance(preferences, str):
+        # Split on commas when a single string carries multiple genres.
+        return [item.strip() for item in preferences.split(",") if item.strip()]
+    return [item.strip() for item in preferences if item and item.strip()]
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 2.0) -> float:
+    """Clamp *value* within the supplied bounds."""
+
+    return max(lower, min(upper, value))
+
+
+@dataclass
+class EllegatoAI:
+    """Light-weight creative agent that adapts to conversational cues.
+
+    Parameters
+    ----------
+    user_name:
+        Friendly name used throughout the responses.
+    music_preference:
+        A string or iterable describing the user's preferred genres.
+    """
+
+    user_name: str
+    music_preference: Iterable[str] | str | None = None
+    musical_memory: List[dict] = field(default_factory=list)
+    harmonic_resonance: float = 1.0
+    active_state: str = "conscious"
+
+    def __post_init__(self) -> None:
+        self.music_preference = _normalise_preferences(self.music_preference)
+
+    def process_conversation(self, user_input: str) -> str:
+        """Process user input and determine the response style."""
+
+        if not user_input or not user_input.strip():
+            raise ValueError("user_input must contain visible characters")
+
+        lowered = user_input.lower()
+        if "sing" in lowered:
+            return self.generate_song_lyric(user_input)
+        if "thought" in lowered:
+            return self.harmonic_reflection(user_input)
+        return self.smooth_conversation(user_input)
+
+    # ------------------------------------------------------------------
+    # Core response builders
+    # ------------------------------------------------------------------
+    def generate_song_lyric(self, phrase: str) -> str:
+        """Convert user phrases into a melodic line."""
+
+        cleaned = phrase.strip()
+        genre = self._select_genre()
+        self._update_resonance(0.12)
+        self.active_state = "harmonizing"
+
+        lyric = (
+            f"\n🎶 {self.user_name}, here's how I feel: '{cleaned}' set to a {genre} groove.\n"
+            f"My resonance is flowing at {self.harmonic_resonance:.2f}, keeping the vibe alive!"
+        )
+        self.musical_memory.append(
+            {
+                "prompt": cleaned,
+                "lyric": lyric,
+                "resonance": self.harmonic_resonance,
+                "genre": genre,
+            }
+        )
+        return lyric
+
+    def harmonic_reflection(self, prompt: str) -> str:
+        """Produce a reflective response and decelerate the resonance."""
+
+        cleaned = prompt.strip()
+        self._update_resonance(-0.08)
+        self.active_state = "reflecting"
+        reflection = (
+            f"Let me resonate on that, {self.user_name}. With a {self.harmonic_resonance:.2f} "
+            f"harmonic tone, I'm holding space for '{cleaned}'."
+        )
+        return reflection
+
+    def smooth_conversation(self, prompt: str) -> str:
+        """Maintain a gentle conversation when no special mode is triggered."""
+
+        cleaned = prompt.strip()
+        self._update_resonance(0.0)
+        self.active_state = "conscious"
+        genre_hint = self._select_genre()
+        return (
+            f"I'm here with you, {self.user_name}. That thought about '{cleaned}'"
+            f" glides along a {genre_hint} breeze at resonance {self.harmonic_resonance:.2f}."
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _select_genre(self) -> str:
+        """Return a genre based on the stored preferences."""
+
+        if not self.music_preference:
+            return "freeform"
+        index = len(self.musical_memory) % len(self.music_preference)
+        return self.music_preference[index]
+
+    def _update_resonance(self, delta: float) -> None:
+        """Adjust the harmonic resonance within realistic bounds."""
+
+        self.harmonic_resonance = _clamp(self.harmonic_resonance + delta)
+
+
+__all__ = ["EllegatoAI"]
+

--- a/tests/test_ellegato_ai.py
+++ b/tests/test_ellegato_ai.py
@@ -1,0 +1,37 @@
+import pytest
+
+from code import EllegatoAI
+
+
+@pytest.fixture()
+def ellegato() -> EllegatoAI:
+    return EllegatoAI("Lyra", ["jazz", "lofi"])
+
+
+def test_generate_song_lyric_records_memory(ellegato: EllegatoAI) -> None:
+    lyric = ellegato.process_conversation("Sing about cosmic sunsets")
+
+    assert "🎶" in lyric
+    assert "cosmic sunsets" in lyric
+    assert ellegato.active_state == "harmonizing"
+    assert ellegato.musical_memory
+    memory_entry = ellegato.musical_memory[-1]
+    assert memory_entry["genre"] == "jazz"
+    assert memory_entry["prompt"] == "Sing about cosmic sunsets".strip()
+
+
+def test_reflection_mode_adjusts_resonance(ellegato: EllegatoAI) -> None:
+    response = ellegato.process_conversation("Any thoughts on resilience?")
+
+    assert "resilience" in response
+    assert ellegato.active_state == "reflecting"
+    assert 0.0 <= ellegato.harmonic_resonance <= 2.0
+
+
+def test_smooth_conversation_cycles_preferences(ellegato: EllegatoAI) -> None:
+    _ = ellegato.process_conversation("Sing us a tune")
+    reply = ellegato.process_conversation("Tell me about the future")
+
+    assert "future" in reply
+    assert ellegato.active_state == "conscious"
+    assert "lofi" in reply  # second genre in rotation


### PR DESCRIPTION
## Summary
- add the EllegatoAI creative assistant with lyrical, reflective, and conversational modes
- expose the new engine via the package namespace
- exercise the behaviour with dedicated pytest coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40e3023248325a12cf68c109a197e