### PR TITLE
Align harmonic cognition module with new schema

### DIFF
--- a/tests/test_harmonic_cognition.py
+++ b/tests/test_harmonic_cognition.py
@@ -4,40 +4,38 @@ from code import HarmonicResponse, HarmonicSettings, harmonic_cognition
 
 
 class HarmonicCognitionTests(unittest.TestCase):
-    def test_expanded_mode_uses_waveform_to_repeat_words(self) -> None:
+    def test_waveform_controls_intensity_markup(self) -> None:
         text = "Reality operates through quantum harmonic resonance"
         settings = HarmonicSettings(
-            waveform="complex",
-            resonance_factor=1.2,
-            compression=False,
-            symbolic_inflection="fractal",
-            harmonic_scaling=0.9,
+            waveform="polyphonic",
+            resonance_factor=1.4,
+            lyricism_mode=False,
+            emotional_tuning="neutral",
         )
 
         response = harmonic_cognition(text, settings=settings)
 
         self.assertIsInstance(response, HarmonicResponse)
-        self.assertGreater(len(response.waveform), 0)
-        self.assertIn("Reality", response.structured_text)
-        self.assertGreaterEqual(len(response.structured_text.split()), len(text.split()))
-        self.assertGreater(response.structured_text.split().count("resonance"), 1)
+        self.assertEqual(len(response.waveform), len(text.split()))
+        emphasised = [word for word in response.structured_text.split() if word.startswith("*")]
+        self.assertTrue(emphasised)
+        self.assertLessEqual(len(response.interpretive_layers), 3)
+        self.assertTrue(all("polyphonic" in layer for layer in response.interpretive_layers))
 
-    def test_compression_mode_highlights_high_intensity_words(self) -> None:
+    def test_lyricism_appends_tagline_and_layers(self) -> None:
         text = "Consciousness emerging from vibrational field interactions"
         settings = HarmonicSettings(
-            waveform="sine",
-            resonance_factor=2.0,
-            compression=True,
-            phase_modulation=True,
-            harmonic_scaling=1.3,
+            waveform="legato",
+            resonance_factor=0.8,
+            lyricism_mode=True,
+            emotional_tuning="uplifting",
         )
 
         response = harmonic_cognition(text, settings=settings)
 
-        emphasised = [word for word in response.structured_text.split() if word.startswith("*")]
-        self.assertTrue(emphasised)
+        self.assertIn("melody ascends toward dawn", response.structured_text)
         self.assertLessEqual(len(response.interpretive_layers), 3)
-        self.assertTrue(all(layer.startswith("[") for layer in response.interpretive_layers))
+        self.assertTrue(any("uplifting" in layer for layer in response.interpretive_layers))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align `HarmonicSettings` with the new waveform, lyricism, and emotional tuning schema
- rework `harmonic_cognition` to emit emphasis markers, interpretive layers, and lyrical tags based on the updated settings
- refresh the harmonic cognition unit tests to cover the revised behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40e7768d083258eef3b63c1a3e68a