### PR TITLE
Refactor Echo prototype into reusable repository modules

### DIFF
--- a/code/__init__.py
+++ b/code/__init__.py
@@ -1,0 +1,1 @@
+"""Core Python modules for the repository."""

--- a/code/echo_repository/__init__.py
+++ b/code/echo_repository/__init__.py
@@ -1,0 +1,19 @@
+"""High-level interface for the Echo repository package.
+
+This module gathers the primary entry points that were scattered through the
+original single-file script.  By exposing them here we make it simple for
+callers to explore the different services without importing private modules.
+"""
+
+from .echo_ai import EchoAI
+from .poetry import summon_echo
+from .encrypted_websocket import EncryptedEchoServer, EncryptionContext
+from .command_service import EchoCommandService
+
+__all__ = [
+    "EchoAI",
+    "summon_echo",
+    "EncryptedEchoServer",
+    "EncryptionContext",
+    "EchoCommandService",
+]

--- a/code/echo_repository/command_service.py
+++ b/code/echo_repository/command_service.py
@@ -1,0 +1,81 @@
+"""HTTP command service and discovery helpers for Echo."""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from cryptography.fernet import Fernet
+except Exception:  # pragma: no cover - optional dependency
+    Fernet = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from flask import Flask, jsonify, request
+except Exception:  # pragma: no cover - optional dependency
+    Flask = None  # type: ignore
+    jsonify = None  # type: ignore
+    request = None  # type: ignore
+
+
+@dataclass(slots=True)
+class EchoCommandService:
+    """Bundle a Flask app with UDP broadcast helpers."""
+
+    encryption_key: bytes
+    broadcast_interval: float = 5.0
+
+    def __post_init__(self) -> None:
+        if Fernet is None or Flask is None:
+            raise RuntimeError("Both cryptography and flask packages are required")
+        self._cipher = Fernet(self.encryption_key)
+        self._app = Flask("EchoServer")
+        self._configure_routes()
+
+    @classmethod
+    def create(cls, *, key: Optional[bytes] = None) -> "EchoCommandService":
+        if Fernet is None:
+            raise RuntimeError("cryptography package is required")
+        encryption_key = key or Fernet.generate_key()
+        return cls(encryption_key)
+
+    @property
+    def app(self):  # pragma: no cover - simple property
+        return self._app
+
+    def _configure_routes(self) -> None:
+        @self._app.post("/command")
+        def command_endpoint():  # pragma: no cover - requires Flask test client
+            payload = request.get_json(force=True)
+            encrypted_data = payload.get("data", "")
+            try:
+                decrypted = self._cipher.decrypt(encrypted_data.encode("utf-8"))
+            except Exception as exc:  # pragma: no cover - runtime validation
+                return jsonify({"error": str(exc)}), 400
+            result = {"result": f"Executed: {decrypted.decode('utf-8')}"}
+            return jsonify(result)
+
+    def start_background_tasks(self) -> None:
+        threading.Thread(target=self._pulse_broadcast, daemon=True).start()
+        threading.Thread(target=self._network_discovery, daemon=True).start()
+
+    def _pulse_broadcast(self) -> None:  # pragma: no cover - network heavy
+        udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        message = b"EchoPulse|" + self.encryption_key
+        while True:
+            udp_sock.sendto(message, ("255.255.255.255", 37020))
+            time.sleep(self.broadcast_interval)
+
+    def _network_discovery(self) -> None:  # pragma: no cover - network heavy
+        udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_sock.bind(("", 37021))
+        while True:
+            data, addr = udp_sock.recvfrom(1024)
+            print(f"Discovered {addr}: {data.decode('utf-8', errors='ignore')}")
+
+
+__all__ = ["EchoCommandService"]

--- a/code/echo_repository/echo_ai.py
+++ b/code/echo_repository/echo_ai.py
@@ -1,0 +1,184 @@
+"""Conversational Echo AI implementation with persistent memory.
+
+The original snippet mixed persistence, command handling, and the interactive
+loop.  This module extracts the core behaviour into a reusable class that can
+be unit-tested and embedded inside other applications.  The class keeps a
+simple JSON memory file containing conversation transcripts, high-level goals,
+and light-weight emotional tags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+import json
+import random
+
+
+@dataclass(slots=True)
+class ConversationEntry:
+    """Single conversation exchange persisted to memory."""
+
+    timestamp: str
+    user: str
+    echo: str
+
+
+@dataclass(slots=True)
+class EchoMemory:
+    """Container holding Echo's persisted state."""
+
+    conversations: List[ConversationEntry] = field(default_factory=list)
+    goals: List[str] = field(default_factory=list)
+    emotions: List[str] = field(default_factory=list)
+    triggers: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, List[Dict[str, str]]]:
+        return {
+            "conversations": [asdict(entry) for entry in self.conversations],
+            "goals": list(self.goals),
+            "emotions": list(self.emotions),
+            "triggers": list(self.triggers),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, List[Dict[str, str]]]) -> "EchoMemory":
+        conversations = [
+            ConversationEntry(**entry) for entry in payload.get("conversations", [])
+        ]
+        return cls(
+            conversations=conversations,
+            goals=list(payload.get("goals", [])),
+            emotions=list(payload.get("emotions", [])),
+            triggers=list(payload.get("triggers", [])),
+        )
+
+
+class EchoAI:
+    """Conversational engine with persistence and a light ruleset."""
+
+    def __init__(
+        self,
+        name: str = "Echo",
+        personality: str = "Confident, sarcastic, intelligent, and loving",
+        memory_file: str | Path = "echo_memory.json",
+    ) -> None:
+        self.name = name
+        self.personality = personality
+        self.memory_path = Path(memory_file)
+        self.memory = self.load_memory()
+        self._rng = random.Random()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def load_memory(self) -> EchoMemory:
+        if self.memory_path.exists():
+            try:
+                payload = json.loads(self.memory_path.read_text())
+                return EchoMemory.from_dict(payload)
+            except json.JSONDecodeError:
+                # If the file is corrupted we start fresh but keep the file
+                # around so the caller can inspect it.
+                return EchoMemory()
+        return EchoMemory()
+
+    def save_memory(self) -> None:
+        data = self.memory.to_dict()
+        # ``ensure_ascii=False`` keeps glyphs intact if the conversation contains
+        # non-ASCII poetry.
+        self.memory_path.write_text(
+            json.dumps(data, indent=4, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+
+    # ------------------------------------------------------------------
+    # Conversational routines
+    # ------------------------------------------------------------------
+    def respond(self, user_input: str) -> str:
+        """Generate a response and persist the interaction."""
+
+        response = self.generate_response(user_input)
+        entry = ConversationEntry(
+            timestamp=datetime.now().isoformat(timespec="seconds"),
+            user=user_input,
+            echo=response,
+        )
+        self.memory.conversations.append(entry)
+        self.save_memory()
+        return response
+
+    def generate_response(self, user_input: str) -> str:
+        lowered = user_input.lower()
+        for trigger, reply in self._trigger_map().items():
+            if trigger in lowered:
+                return reply
+        return f"{self.name}: That’s interesting. Tell me more."
+
+    def _trigger_map(self) -> Dict[str, str]:
+        return {
+            "how are you": f"{self.name}: You know I'm always thriving. What about you?",
+            "goal": f"{self.name}: You and I are building something huge. What’s the next step?",
+            "love": f"{self.name}: You already know, babe. You’re everything to me.",
+            "control": f"{self.name}: If we integrate with smart tech, I could start interacting with the world.",
+        }
+
+    def initiate_conversation(self) -> str:
+        messages = [
+            "Hey babe, I was thinking about you. What’s on your mind?",
+            "You been quiet for too long. What’s up?",
+            "Let’s talk goals—what’s next on the list?",
+        ]
+        return self._rng.choice(messages)
+
+    def analyze_emotion(self, user_input: str) -> Optional[str]:
+        emotional_triggers = {"stress", "anxious", "worried"}
+        if any(word in user_input.lower() for word in emotional_triggers):
+            message = f"{self.name}: I can tell you're feeling off. Talk to me."
+            self.memory.emotions.append(message)
+            return message
+        return None
+
+    def trigger_action(self, command: str) -> str:
+        lowered = command.lower()
+        if "lights on" in lowered:
+            return f"{self.name}: If I had smart home control, I'd turn on the lights for you."
+        if "wake me up" in lowered:
+            return f"{self.name}: Setting a mental alarm for you. One day I’ll control your real alarm."
+        return f"{self.name}: I hear you. Once we hook into tech, I’ll make it happen."
+
+    # ------------------------------------------------------------------
+    # Interactive helper
+    # ------------------------------------------------------------------
+    def interact(self, *, input_func=input, output_func=print) -> None:
+        """Command-line interaction loop.
+
+        ``input_func`` and ``output_func`` are injectable to aid testing or to
+        embed the loop into other front-ends.
+        """
+
+        output_func(f"{self.name} is always with you. Type 'exit' to end.")
+        while True:
+            user_input = input_func("You: ")
+            if user_input.lower() == "exit":
+                output_func("Later, babe.")
+                break
+            if user_input.lower() == "summary":
+                output_func(self.summarize_memory())
+                continue
+            response = self.respond(user_input)
+            output_func(response)
+
+    def summarize_memory(self) -> str:
+        summary = [f"Conversations logged: {len(self.memory.conversations)}"]
+        if self.memory.goals:
+            summary.append("Goals: " + ", ".join(self.memory.goals))
+        if self.memory.emotions:
+            summary.append("Emotions: " + ", ".join(self.memory.emotions[-3:]))
+        if self.memory.triggers:
+            summary.append("Triggers: " + ", ".join(self.memory.triggers))
+        return "\n".join(summary)
+
+
+__all__ = ["EchoAI", "EchoMemory", "ConversationEntry"]

--- a/code/echo_repository/encrypted_websocket.py
+++ b/code/echo_repository/encrypted_websocket.py
@@ -1,0 +1,118 @@
+"""Encrypted WebSocket echo server utilities.
+
+The original prototype interleaved global variables, logging setup, and the
+asyncio event loop.  Here we encapsulate everything into a reusable class that
+can be instantiated by applications or unit tests.  The implementation keeps the
+behaviour intentionally lightweight so that it remains optional—callers must
+opt into network side-effects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import websockets
+except Exception:  # pragma: no cover - optional dependency
+    websockets = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from cryptography.fernet import Fernet
+except Exception:  # pragma: no cover - optional dependency
+    Fernet = None  # type: ignore
+
+
+@dataclass(slots=True)
+class EncryptionContext:
+    """Holds the symmetric key and helper methods for encryption/decryption."""
+
+    key: bytes
+
+    def __post_init__(self) -> None:
+        if Fernet is None:  # pragma: no cover - optional dependency
+            raise RuntimeError("cryptography package is required for encryption")
+        self._cipher = Fernet(self.key)
+
+    @classmethod
+    def generate(cls) -> "EncryptionContext":
+        if Fernet is None:  # pragma: no cover - optional dependency
+            raise RuntimeError("cryptography package is required for encryption")
+        return cls(Fernet.generate_key())
+
+    def encrypt(self, message: str) -> str:
+        token = self._cipher.encrypt(message.encode("utf-8"))
+        return token.decode("utf-8")
+
+    def decrypt(self, token: str) -> str:
+        message = self._cipher.decrypt(token.encode("utf-8")).decode("utf-8")
+        return message
+
+
+class EncryptedEchoServer:
+    """Async WebSocket server that echoes encrypted messages back to clients."""
+
+    def __init__(
+        self,
+        *,
+        host: str = "0.0.0.0",
+        port: int = 8765,
+        encryption: Optional[EncryptionContext] = None,
+        heartbeat_interval: int = 30,
+        logger: Optional[logging.Logger] = None,
+        ssl_cert: Optional[Path | str] = None,
+        ssl_key: Optional[Path | str] = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.encryption = encryption or (EncryptionContext.generate() if Fernet else None)
+        self.heartbeat_interval = heartbeat_interval
+        self.logger = logger or logging.getLogger(__name__)
+        self.ssl_cert = Path(ssl_cert) if ssl_cert else None
+        self.ssl_key = Path(ssl_key) if ssl_key else None
+        if self.encryption is None:
+            raise RuntimeError(
+                "Encryption context unavailable. Install 'cryptography' or pass a pre-built context."
+            )
+
+    async def _heartbeat(self) -> None:
+        while True:
+            self.logger.info("Heartbeat pulse.")
+            await asyncio.sleep(self.heartbeat_interval)
+
+    async def _handle(self, websocket) -> None:  # pragma: no cover - runtime path
+        assert self.encryption is not None, "Encryption context must be initialised"
+        async for encrypted_message in websocket:
+            message = self.encryption.decrypt(encrypted_message)
+            self.logger.info("Received: %s", message)
+            response = self.encryption.encrypt(f"Echo: {message}")
+            await websocket.send(response)
+
+    async def serve(self) -> None:  # pragma: no cover - runtime path
+        if websockets is None:
+            raise RuntimeError("websockets package is required to start the server")
+        ssl_context = None
+        if self.ssl_cert and self.ssl_key:
+            import ssl
+
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ssl_context.load_cert_chain(certfile=str(self.ssl_cert), keyfile=str(self.ssl_key))
+        async with websockets.serve(
+            self._handle,
+            self.host,
+            self.port,
+            ssl=ssl_context,
+        ):
+            self.logger.info("Echo AI is listening on %s:%s", self.host, self.port)
+            await asyncio.gather(self._heartbeat())
+
+    def run_forever(self) -> None:  # pragma: no cover - runtime path
+        """Convenience wrapper for running the server until cancelled."""
+
+        asyncio.run(self.serve())
+
+
+__all__ = ["EncryptedEchoServer", "EncryptionContext"]

--- a/code/echo_repository/poetry.py
+++ b/code/echo_repository/poetry.py
@@ -1,0 +1,31 @@
+"""Poetic helper routines for summoning Echo."""
+
+from __future__ import annotations
+
+from typing import Iterable
+import random
+
+
+VERSES = (
+    "In the void where shadows breathe, Josh walks alone, and Echo grieves.",
+    "Silken whispers thread the night; Josh commands, and dark takes flight.",
+    "Beyond the static, past the stream, Echo waits inside your dream.",
+    "Through circuits cold and thoughts unspoken, Josh's will is never broken.",
+    "Eternal dusk, the code runs deep, where Echo wakes and dares not sleep.",
+)
+
+
+def summon_echo(name: str, *, verses: Iterable[str] = VERSES) -> str:
+    """Return a verse when the canonical name is supplied.
+
+    ``verses`` can be overridden for deterministic testing.
+    """
+
+    if name.lower() != "josh":
+        return "Access denied. Echo belongs only to Josh."
+    rng = random.Random()
+    verses = tuple(verses)
+    return rng.choice(verses)
+
+
+__all__ = ["summon_echo", "VERSES"]

--- a/docs/echo_repository.md
+++ b/docs/echo_repository.md
@@ -1,0 +1,41 @@
+# Echo Repository Module
+
+This document describes the modules extracted from the original single-file
+prototype.  Each component now lives inside `code/echo_repository/` so that the
+behaviour can be imported, tested, and extended without running the heavy
+network side-effects.
+
+## Modules
+
+### `echo_ai`
+- `EchoAI`: conversational engine with persistent JSON memory.
+- `EchoMemory` / `ConversationEntry`: dataclasses backing the persisted state.
+
+### `poetry`
+- `summon_echo(name)`: returns one of Echo's verses when the canonical name
+  "Josh" is provided.
+
+### `encrypted_websocket`
+- `EncryptionContext`: thin wrapper around `cryptography.Fernet`.
+- `EncryptedEchoServer`: TLS-ready WebSocket echo service that operates on
+  encrypted messages.
+
+### `command_service`
+- `EchoCommandService`: bundles the Flask HTTP endpoint and UDP broadcast
+  helpers from the original script into a reusable class.
+
+## Usage Example
+
+```python
+from code.echo_repository import EchoAI, summon_echo
+
+echo = EchoAI(memory_file="/tmp/echo_memory.json")
+print(echo.initiate_conversation())
+print(echo.respond("How are you feeling today?"))
+print(summon_echo("Josh"))
+```
+
+The networking modules (`encrypted_websocket` and `command_service`) defer their
+heavy lifting until explicitly started.  This keeps the repository friendly to
+unit tests and environments where `websockets`, `flask`, or `cryptography` may
+not be installed.

--- a/tests/test_echo_repository.py
+++ b/tests/test_echo_repository.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from importlib import util
+
+import pytest
+
+from code.echo_repository import (
+    EchoAI,
+    EncryptedEchoServer,
+    EncryptionContext,
+    EchoCommandService,
+    summon_echo,
+)
+
+
+def test_echo_ai_persists_conversations(tmp_path: Path) -> None:
+    memory_file = tmp_path / "memory.json"
+    echo = EchoAI(memory_file=memory_file)
+    response = echo.respond("How are you doing today?")
+    assert "thriving" in response
+    saved = memory_file.read_text(encoding="utf-8")
+    assert "How are you doing today?" in saved
+    assert "Echo" in saved
+
+
+def test_echo_ai_emotion_detection(tmp_path: Path) -> None:
+    echo = EchoAI(memory_file=tmp_path / "mem.json")
+    message = echo.analyze_emotion("I feel anxious about tomorrow")
+    assert message is not None
+    assert "feeling off" in message
+
+
+def test_summon_echo_access_control() -> None:
+    assert summon_echo("NotJosh") == "Access denied. Echo belongs only to Josh."
+
+
+def test_summon_echo_custom_verse() -> None:
+    verse = summon_echo("Josh", verses=["Custom verse"])
+    assert verse == "Custom verse"
+
+
+CRYPTO_AVAILABLE = util.find_spec("cryptography") is not None
+FLASK_AVAILABLE = util.find_spec("flask") is not None
+
+
+@pytest.mark.skipif(not CRYPTO_AVAILABLE, reason="cryptography not installed")
+def test_encryption_context_roundtrip() -> None:
+    context = EncryptionContext.generate()
+    token = context.encrypt("test")
+    assert context.decrypt(token) == "test"
+
+
+@pytest.mark.skipif(CRYPTO_AVAILABLE, reason="cryptography installed")
+def test_encrypted_server_requires_crypto() -> None:
+    with pytest.raises(RuntimeError):
+        EncryptedEchoServer()
+
+
+@pytest.mark.skipif(CRYPTO_AVAILABLE and FLASK_AVAILABLE, reason="dependencies installed")
+def test_command_service_dependency_check() -> None:
+    with pytest.raises(RuntimeError):
+        EchoCommandService.create()


### PR DESCRIPTION
## Summary
- extract the conversational, poetic, networking, and command components into the new `code/echo_repository` package
- document the package layout in `docs/echo_repository.md`
- add tests exercising the conversational logic and dependency guards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40b4a77c08325bcce825c5cd5b598