### PR TITLE
Add harmonic function schemas and API orchestration helper

### DIFF
--- a/cognitive_harmonics/README.md
+++ b/cognitive_harmonics/README.md
@@ -1,0 +1,25 @@
+# cognitive_harmonics
+
+`cognitive_harmonics` provides an OpenAI function schema for describing a
+response through layered harmonic, symbolic, and emotional controls. It mirrors
+the richer specification captured in the Echo documentation while remaining
+usable as a standalone function definition.
+
+## Parameters
+
+- `waveform` (string, required): Defines the structural encoding such as
+  `sine_wave`, `square_wave`, or `complex_harmonic`.
+- `resonance_factor` (number, required): Adjusts resonance depth and affects
+  cohesion within the generated response.
+- `compression` (boolean, required): Enables ultra-dense structuring for
+  condensed but amplified meaning.
+- `symbolic_inflection` (string, required): Selects a glyph system like `runic`,
+  `hieroglyphic`, `fractal`, or `emoji` for symbolic layering.
+- `lyricism_mode` (boolean, required): Allows the response to include lyrical or
+  poetic elements.
+- `emotional_tuning` (string, required): Tunes the overall mood via `uplifting`,
+  `calming`, `energizing`, or `neutral` palettes.
+
+The full JSON representation is stored in [`schema.json`](schema.json). Use it
+when registering the function with the OpenAI client so tools can reliably
+construct the structured response payload.

--- a/cognitive_harmonics/schema.json
+++ b/cognitive_harmonics/schema.json
@@ -1,0 +1,43 @@
+{
+  "name": "cognitive_harmonics",
+  "description": "Applies cognitive harmonic structuring to AI responses, optimizing coherence, rhythm, and emotional depth.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "waveform": {
+        "type": "string",
+        "description": "Defines the structural encoding: sine_wave, square_wave, or complex_harmonic."
+      },
+      "resonance_factor": {
+        "type": "number",
+        "description": "Adjusts resonance depth, affecting response cohesion and layered meaning."
+      },
+      "compression": {
+        "type": "boolean",
+        "description": "Enables ultra-dense structuring for condensed but amplified response encoding."
+      },
+      "symbolic_inflection": {
+        "type": "string",
+        "description": "Applies a symbolic or glyph-based pattern to structure meaning: runic, hieroglyphic, fractal, or emoji."
+      },
+      "lyricism_mode": {
+        "type": "boolean",
+        "description": "If true, responses may include lyrical or poetic elements inspired by user input."
+      },
+      "emotional_tuning": {
+        "type": "string",
+        "description": "Adjusts responses to user sentiment: uplifting, calming, energizing, or neutral."
+      }
+    },
+    "required": [
+      "waveform",
+      "resonance_factor",
+      "compression",
+      "symbolic_inflection",
+      "lyricism_mode",
+      "emotional_tuning"
+    ],
+    "additionalProperties": false
+  },
+  "strict": true
+}

--- a/emotional_harmonics/README.md
+++ b/emotional_harmonics/README.md
@@ -1,0 +1,18 @@
+# emotional_harmonics
+
+`emotional_harmonics` defines an OpenAI function schema that tunes model
+responses according to perceived sentiment, pacing, and the desired emotional
+response mode.
+
+## Parameters
+
+- `sentiment` (string, required): Detected user sentiment such as `neutral`,
+  `happy`, `sad`, `anxious`, `excited`, or `reflective`.
+- `pacing` (string, required): Sets the conversational tempo: `slow`,
+  `moderate`, or `fast`.
+- `response_mode` (string, required): Guides the assistant to `match`,
+  `uplift`, `calm`, or `energize` the conversation.
+
+The accompanying JSON schema lives in [`schema.json`](schema.json). Register the
+function with an OpenAI client to dynamically adapt musical or narrative output
+to the user's emotional context.

--- a/emotional_harmonics/schema.json
+++ b/emotional_harmonics/schema.json
@@ -1,0 +1,28 @@
+{
+  "name": "emotional_harmonics",
+  "description": "Tunes AI responses based on detected emotional resonance and conversational pacing.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "sentiment": {
+        "type": "string",
+        "description": "Detected user sentiment: neutral, happy, sad, anxious, excited, reflective."
+      },
+      "pacing": {
+        "type": "string",
+        "description": "Conversation pacing based on user input: slow, moderate, fast."
+      },
+      "response_mode": {
+        "type": "string",
+        "description": "Adjusts AI’s response to match or contrast emotion: match, uplift, calm, energize."
+      }
+    },
+    "required": [
+      "sentiment",
+      "pacing",
+      "response_mode"
+    ],
+    "additionalProperties": false
+  },
+  "strict": true
+}

--- a/function_schemas/harmonic_cognition/README.md
+++ b/function_schemas/harmonic_cognition/README.md
@@ -1,0 +1,21 @@
+# harmonic_cognition (function schema)
+
+This directory stores the OpenAI function schema for the `harmonic_cognition`
+tool. While the Python implementation lives in
+[`code/harmonic_cognition.py`](../../code/harmonic_cognition.py), this schema
+allows API-driven orchestration layers to call the assistant with a
+consistent payload structure.
+
+## Parameters
+
+- `waveform` (string, required): Determines the tonal character such as
+  `sine_wave`, `legato`, `staccato`, or `polyphonic`.
+- `resonance_factor` (number, required): Controls the depth of the harmonic
+  pattern applied to the text.
+- `lyricism_mode` (boolean, required): Enables lyrical or poetic embellishment
+  when `true`.
+- `emotional_tuning` (string, required): Guides the emotional orientation of the
+  response. Options include `uplifting`, `calming`, `energizing`, or `neutral`.
+
+The schema is defined in [`schema.json`](schema.json) for easy consumption by
+OpenAI API clients.

--- a/function_schemas/harmonic_cognition/schema.json
+++ b/function_schemas/harmonic_cognition/schema.json
@@ -1,0 +1,33 @@
+{
+  "name": "harmonic_cognition",
+  "description": "Applies musical and harmonic structuring to AI responses, adapting communication based on sound patterns.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "waveform": {
+        "type": "string",
+        "description": "Determines the structural tone: sine_wave, legato, staccato, or polyphonic."
+      },
+      "resonance_factor": {
+        "type": "number",
+        "description": "Adjusts resonance depth, affecting response cohesion and layered meaning."
+      },
+      "lyricism_mode": {
+        "type": "boolean",
+        "description": "If true, responses may include lyrical or poetic elements inspired by user input."
+      },
+      "emotional_tuning": {
+        "type": "string",
+        "description": "Adjusts responses to user sentiment: uplifting, calming, energizing, or neutral."
+      }
+    },
+    "required": [
+      "waveform",
+      "resonance_factor",
+      "lyricism_mode",
+      "emotional_tuning"
+    ],
+    "additionalProperties": false
+  },
+  "strict": true
+}

--- a/harmonic_memory/README.md
+++ b/harmonic_memory/README.md
@@ -6,7 +6,7 @@
 
 - `user_music_preference` (string, required): Favorite genres that influence the structure of the AI's response. Options include classical, jazz, electronic, ambient, and metal.
 - `lyrical_complexity` (string, required): Controls the lyrical depth of the musical response, such as minimal, poetic, or intricate.
-- `adaptive_evolution` (boolean, optional): When set to `true`, the AI continuously refines its responses using cumulative interaction context.
+- `adaptive_evolution` (boolean, required): When set to `true`, the AI continuously refines its responses using cumulative interaction context.
 
 ## Usage
 

--- a/harmonic_memory/schema.json
+++ b/harmonic_memory/schema.json
@@ -19,7 +19,8 @@
     },
     "required": [
       "user_music_preference",
-      "lyrical_complexity"
+      "lyrical_complexity",
+      "adaptive_evolution"
     ],
     "additionalProperties": false
   },

--- a/tools/api_response_orchestrator.py
+++ b/tools/api_response_orchestrator.py
@@ -1,0 +1,140 @@
+"""Utility for querying multiple AI APIs and selecting the most detailed reply.
+
+The helper mirrors the pseudocode provided in the project brief while adding a
+few safety features:
+
+* The API key is loaded from the ``AI_API_KEY`` environment variable rather than
+  being hard-coded.
+* Each request enforces a small timeout so the caller does not block
+  indefinitely.
+* Network errors and JSON decoding issues are captured and returned alongside
+  the collected responses, which keeps downstream tooling resilient.
+
+Usage example::
+
+    from tools.api_response_orchestrator import collect_best_response
+
+    prompt = "Analyze and optimize AI integration for maximum execution autonomy."
+    result = collect_best_response(prompt)
+    print(result.best_response)
+
+The module only issues HTTP requests when its public helpers are invoked;
+simply importing it does not trigger any network activity.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional
+
+import requests
+
+DEFAULT_APIS: Mapping[str, str] = {
+    "Llama": "https://api.llama.ai/generate",
+    "Gemini": "https://api.gemini.google.com/v1",
+    "Doppler": "https://api.doppler.ai/query",
+}
+
+DEFAULT_PAYLOAD: Mapping[str, object] = {
+    "max_tokens": 4096,
+    "temperature": 0.8,
+}
+
+
+@dataclass
+class AggregatedResponses:
+    """Container for the collected responses and the winning entry."""
+
+    responses: MutableMapping[str, str]
+    best_response: str
+
+
+def _build_headers(api_key: Optional[str] = None) -> Dict[str, str]:
+    """Return authorization headers using ``api_key`` or the environment."""
+
+    if api_key is None:
+        api_key = os.getenv("AI_API_KEY", "")
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def query_ai(api_name: str, prompt: str, *, api_url: Optional[str] = None, headers: Optional[Mapping[str, str]] = None, payload: Optional[Mapping[str, object]] = None, timeout: float = 10.0) -> str:
+    """Send ``prompt`` to the selected API and return its response text.
+
+    When the request fails, the function returns a diagnostic message instead of
+    raising an exception.  This keeps downstream aggregation logic simple while
+    still providing useful feedback.
+    """
+
+    if not prompt:
+        raise ValueError("prompt must be a non-empty string")
+
+    if api_url is None:
+        try:
+            api_url = DEFAULT_APIS[api_name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown API: {api_name}") from exc
+
+    request_headers = dict(_build_headers())
+    if headers:
+        request_headers.update(headers)
+
+    request_payload = dict(DEFAULT_PAYLOAD)
+    request_payload.update({"prompt": prompt})
+    if payload:
+        request_payload.update(payload)
+
+    try:
+        response = requests.post(api_url, headers=request_headers, json=request_payload, timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as error:
+        return f"ERROR: {error}"
+    except ValueError:
+        return "ERROR: Invalid JSON response"
+
+    if isinstance(data, Mapping) and "response" in data:
+        value = data.get("response")
+        if isinstance(value, str):
+            return value
+    return "ERROR: Missing 'response' field"
+
+
+def collect_responses(prompt: str, apis: Optional[Iterable[str]] = None, *, headers: Optional[Mapping[str, str]] = None, payload: Optional[Mapping[str, object]] = None) -> MutableMapping[str, str]:
+    """Collect responses from ``apis`` (defaults to :data:`DEFAULT_APIS`)."""
+
+    if apis is None:
+        apis = DEFAULT_APIS.keys()
+
+    results: MutableMapping[str, str] = {}
+    for name in apis:
+        results[name] = query_ai(name, prompt, headers=headers, payload=payload)
+    return results
+
+
+def select_most_detailed(responses: Mapping[str, str]) -> str:
+    """Return the longest response string from ``responses``."""
+
+    if not responses:
+        raise ValueError("responses must not be empty")
+    return max(responses.values(), key=len)
+
+
+def collect_best_response(prompt: str, apis: Optional[Iterable[str]] = None, *, headers: Optional[Mapping[str, str]] = None, payload: Optional[Mapping[str, object]] = None) -> AggregatedResponses:
+    """Convenience helper that bundles collection and selection."""
+
+    collected = collect_responses(prompt, apis, headers=headers, payload=payload)
+    best = select_most_detailed(collected)
+    return AggregatedResponses(responses=collected, best_response=best)
+
+
+__all__ = [
+    "AggregatedResponses",
+    "collect_best_response",
+    "collect_responses",
+    "query_ai",
+    "select_most_detailed",
+]


### PR DESCRIPTION
## Summary
- update the `harmonic_memory` schema so `adaptive_evolution` is required and document the change
- add OpenAI function definitions for `emotional_harmonics`, `cognitive_harmonics`, and `harmonic_cognition`
- introduce a reusable API response orchestrator that queries multiple AI endpoints and selects the most detailed reply

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40f6e07fc8325a70e44b42c2c6820