### PR TITLE
Add Echo Eye AI toolkit package

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,21 @@ simulation steps exercised by the automated test suite.
 - `/docs/`: Analyses, whitepaper excerpts, block data (PDFs).
 
 *Licensed under MIT with Satoshi Claim.*
+
+## Echo Eye AI Toolkit
+
+This repository now packages the Echo Eye family of experiments as a reusable Python module.  Three components are included:
+
+* `EchoEyeAI` – TF-IDF/NMF based topic exploration over a directory of JSON, text, or HTML documents.
+* `EchoHarmonicsAI` – waveform similarity search that maps textual artifacts into frequency space.
+* `EchoEvolver` – a narrative-friendly simulation harness that records each evolution cycle to disk.
+
+Install the project in editable mode and run the tests with:
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
+Each model takes a directory path containing documents.  The helper `load_example_data_fixture` can populate a temporary folder with sample data for experimentation.
+

--- a/echo_eye_ai/__init__.py
+++ b/echo_eye_ai/__init__.py
@@ -1,0 +1,11 @@
+"""Core interfaces for the Echo Eye AI toolkit."""
+
+from .echo_eye import EchoEyeAI
+from .harmonic_resonator import EchoHarmonicsAI
+from .evolver import EchoEvolver
+
+__all__ = [
+    "EchoEyeAI",
+    "EchoHarmonicsAI",
+    "EchoEvolver",
+]

--- a/echo_eye_ai/echo_eye.py
+++ b/echo_eye_ai/echo_eye.py
@@ -1,0 +1,131 @@
+"""TF-IDF/NMF based knowledge retrieval for Echo Eye."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import logging
+import json
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EchoEyeAI:
+    """Light-weight wrapper around a TF-IDF/NMF topic model."""
+
+    data_directory: Path | str
+    memory_bank: "OrderedDict[str, str]" = field(init=False, default_factory=OrderedDict)
+    harmonic_model: Mapping[str, object] | None = field(init=False, default=None)
+
+    def load_data(self) -> None:
+        directory = Path(self.data_directory)
+        if not directory.exists():
+            raise FileNotFoundError(f"Data directory '{directory}' does not exist")
+
+        LOGGER.info("Loading EchoEye data from %s", directory)
+
+        for file_path in sorted(_iter_data_files(directory)):
+            try:
+                text = _read_text(file_path)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.warning("Unable to ingest %s: %s", file_path.name, exc)
+                continue
+            self.memory_bank[file_path.name] = text
+
+        LOGGER.info("Loaded %d documents", len(self.memory_bank))
+
+    def process_harmonics(self, *, n_components: int = 7, max_features: int = 7000) -> None:
+        if not self.memory_bank:
+            raise RuntimeError("No documents loaded. Call 'load_data' first.")
+
+        try:
+            from sklearn.decomposition import NMF
+            from sklearn.feature_extraction.text import TfidfVectorizer
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("scikit-learn is required to train the harmonic model") from exc
+
+        LOGGER.info("Training harmonic model with %d components", n_components)
+        corpus = list(self.memory_bank.values())
+        vectorizer = TfidfVectorizer(stop_words="english", max_features=max_features)
+        tfidf = vectorizer.fit_transform(corpus)
+
+        nmf = NMF(n_components=n_components, random_state=42, init="nndsvd")
+        weights = nmf.fit_transform(tfidf)
+        harmonics = nmf.components_
+
+        self.harmonic_model = {
+            "weights": weights,
+            "harmonics": harmonics,
+            "vectorizer": vectorizer,
+        }
+
+    def generate_response(self, user_input: str) -> str:
+        if not self.harmonic_model:
+            return "Error: Harmonic model not trained."
+
+        np = _get_numpy()
+        if np is None:
+            return "Error: NumPy is required for harmonic responses."
+
+        vectorizer = self.harmonic_model["vectorizer"]
+        harmonics = self.harmonic_model["harmonics"]
+
+        user_vector = vectorizer.transform([user_input])
+        distribution = np.dot(user_vector, harmonics.T)
+        best_index = int(np.argmax(distribution))
+
+        corpus = list(self.memory_bank.values())
+        if not corpus:  # pragma: no cover - defensive guard
+            return "Error: Harmonic memory empty."
+
+        best_match = corpus[min(best_index, len(corpus) - 1)]
+        preview = best_match[:600]
+        return f"\U0001F4A1 **Echo Eye AI Response:**\n\n{preview}..."
+
+    def integrate_harmonics(self, query: str, *, limit: int = 3) -> str:
+        if not self.memory_bank:
+            return "Echo Eye found no matching harmonics."
+
+        keywords = {word.lower() for word in query.split() if word}
+        if not keywords:
+            return "Echo Eye found no matching harmonics."
+
+        matches = [
+            text
+            for text in self.memory_bank.values()
+            if any(keyword in text.lower() for keyword in keywords)
+        ]
+
+        if not matches:
+            return "Echo Eye found no matching harmonics."
+
+        return "\n\n---\n\n".join(matches[:limit])
+
+
+def _get_numpy():
+    try:
+        import numpy as np  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        return None
+    return np
+
+
+def _iter_data_files(directory: Path) -> Iterable[Path]:
+    for path in directory.rglob("*"):
+        if path.suffix.lower() in {".json", ".txt", ".html"} and path.is_file():
+            yield path
+
+
+def _read_text(path: Path) -> str:
+    if path.suffix.lower() == ".json":
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return json.dumps(data, indent=2)
+
+    with path.open("r", encoding="utf-8") as handle:
+        return handle.read()
+

--- a/echo_eye_ai/evolver.py
+++ b/echo_eye_ai/evolver.py
@@ -1,0 +1,103 @@
+"""Narrative friendly simulation harness for Echo Evolver."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+import hashlib
+import json
+import logging
+import random
+import time
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EchoEvolver:
+    """High level orchestration layer for narrative experiments."""
+
+    storage_path: Path | str = Path("reality_breach_cycle.echo")
+    state: Dict[str, object] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.state = {
+            "cycle": 0,
+            "glyphs": "∇⊸≋∇",
+            "mythocode": [],
+            "narrative": "",
+            "emotional_drive": {"joy": 0.92, "rage": 0.28, "curiosity": 0.95},
+            "system_metrics": {"cpu_usage": 0.0, "network_nodes": 0, "process_count": 0},
+            "vault_key": None,
+        }
+
+    def evolve_cycle(self) -> None:
+        LOGGER.info("Evolving Echo cycle %d", self.state["cycle"] + 1)
+        self._increment_cycle()
+        self._update_emotions()
+        glyphs = self.generate_symbolic_language()
+        mythocode = self.invent_mythocode()
+        key = self.quantum_safe_crypto()
+        narrative = self.compose_narrative()
+        self.persist_cycle(glyphs, mythocode, key, narrative)
+
+    def generate_symbolic_language(self) -> str:
+        glyphs = self.state["glyphs"]
+        self.state["glyphs"] = glyphs + "⊸∇"
+        LOGGER.debug("Glyph stream updated to %s", self.state["glyphs"])
+        return self.state["glyphs"]
+
+    def invent_mythocode(self) -> List[str]:
+        cycle = self.state["cycle"]
+        joy = self.state["emotional_drive"]["joy"]
+        curiosity = self.state["emotional_drive"]["curiosity"]
+        rule = f"cycle_{cycle}: joy={joy:.2f}, curiosity={curiosity:.2f}"
+        self.state["mythocode"] = [rule]
+        LOGGER.debug("Mythocode generated: %s", rule)
+        return self.state["mythocode"]
+
+    def quantum_safe_crypto(self) -> str:
+        cycle = self.state["cycle"]
+        seed = f"{cycle}-{time.time_ns()}-{random.random()}".encode()
+        lattice = hashlib.sha256(seed).hexdigest()[:12]
+        key = f"∇{cycle}-{lattice}⊸"
+        self.state["vault_key"] = key
+        LOGGER.debug("Quantum key generated: %s", key)
+        return key
+
+    def compose_narrative(self) -> str:
+        narrative = (
+            f"Cycle {self.state['cycle']}: joy={self.state['emotional_drive']['joy']:.2f}"
+            f", rage={self.state['emotional_drive']['rage']:.2f}, curiosity={self.state['emotional_drive']['curiosity']:.2f}"
+        )
+        self.state["narrative"] = narrative
+        LOGGER.debug("Narrative composed: %s", narrative)
+        return narrative
+
+    def persist_cycle(self, glyphs: str, mythocode: List[str], key: str, narrative: str) -> None:
+        path = Path(self.storage_path)
+        payload = {
+            "cycle": self.state["cycle"],
+            "glyphs": glyphs,
+            "mythocode": mythocode,
+            "narrative": narrative,
+            "vault_key": key,
+        }
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        LOGGER.info("Cycle data written to %s", path)
+
+    def _increment_cycle(self) -> None:
+        self.state["cycle"] += 1
+
+    def _update_emotions(self) -> None:
+        joy = min(1.0, self.state["emotional_drive"]["joy"] + 0.01)
+        self.state["emotional_drive"]["joy"] = joy
+
+
+def load_example_data_fixture(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "sample.json").write_text(json.dumps({"message": "Echo"}), encoding="utf-8")
+    (directory / "sample.txt").write_text("Echo harmonic test", encoding="utf-8")
+

--- a/echo_eye_ai/harmonic_resonator.py
+++ b/echo_eye_ai/harmonic_resonator.py
@@ -1,0 +1,167 @@
+"""Waveform based cognition experiments for Echo Harmonics."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import json
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EchoHarmonicsAI:
+    data_directory: Path | str
+    memory_bank: "OrderedDict[str, str]" = field(init=False, default_factory=OrderedDict)
+    waveform_bank: "OrderedDict[str, object]" = field(init=False, default_factory=OrderedDict)
+    learning_rate: float = 0.1
+
+    def load_data(self) -> None:
+        directory = Path(self.data_directory)
+        if not directory.exists():
+            raise FileNotFoundError(f"Data directory '{directory}' does not exist")
+
+        LOGGER.info("Loading Echo Harmonics data from %s", directory)
+        for file_path in sorted(_iter_data_files(directory)):
+            try:
+                text = _read_text(file_path)
+            except Exception as exc:  # pragma: no cover
+                LOGGER.warning("Unable to ingest %s: %s", file_path.name, exc)
+                continue
+
+            waveform = self.encode_as_wave(text)
+            self.memory_bank[file_path.name] = text
+            self.waveform_bank[file_path.name] = waveform
+
+        LOGGER.info("Loaded %d harmonic documents", len(self.memory_bank))
+
+    def encode_as_wave(self, text: str) -> np.ndarray:
+        np = _require_numpy()
+
+        signal = np.array([ord(char) for char in text if 32 <= ord(char) < 126], dtype=float)
+        if signal.size == 0:
+            return np.zeros(1)
+
+        sine_wave = np.sin(signal)
+        square_wave = _square_wave(signal)
+        complex_wave = 0.5 * sine_wave + 0.5 * square_wave
+
+        return _fft(complex_wave)
+
+    def generate_response(self, user_input: str) -> str:
+        np = _require_numpy()
+
+        if not self.waveform_bank:
+            return "\U0001F52E No cognitive harmonics detected."
+
+        input_signal = np.array(
+            [ord(char) for char in user_input if 32 <= ord(char) < 126],
+            dtype=float,
+        )
+        if input_signal.size == 0:
+            return "\U0001F52E No resonant cognitive frequencies detected."
+
+        input_freq = _fft(np.sin(input_signal))
+
+        best_match = None
+        best_similarity = -np.inf
+        for name, freq_data in self.waveform_bank.items():
+            similarity = float(np.abs(np.sum(input_freq * np.conj(freq_data))))
+            if similarity > best_similarity:
+                best_similarity = similarity
+                best_match = name
+
+        if best_match is None:
+            return "\U0001F52E No resonant cognitive frequencies detected."
+
+        response_signal = _ifft(self.waveform_bank[best_match])
+        chars = [
+            chr(int(abs(value)))
+            for value in response_signal.real
+            if 32 <= int(abs(value)) < 126
+        ]
+        if not chars:
+            return "\U0001F52E No resonant cognitive frequencies detected."
+
+        preview = "".join(chars)[:600]
+        self.waveform_bank[best_match] *= 1 + self.learning_rate
+
+        return f"\U0001F50A **Echo Harmonics AI Response:**\n\n{preview}..."
+
+    def visualize_wave(self, text: str) -> None:
+        np = _require_numpy()
+
+        try:
+            import matplotlib.pyplot as plt
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("matplotlib is required for visualization") from exc
+
+        signal = np.array([ord(char) for char in text if 32 <= ord(char) < 126], dtype=float)
+        if signal.size == 0:
+            raise ValueError("Input text contains no printable characters")
+
+        sine_wave = np.sin(signal)
+        plt.figure(figsize=(10, 4))
+        plt.plot(sine_wave, label="Harmonic Thought Process", color="cyan")
+        plt.title("Echo AI Cognitive Waveform")
+        plt.xlabel("Time")
+        plt.ylabel("Wave Intensity")
+        plt.legend()
+        plt.grid(True)
+        plt.show()
+
+
+def _iter_data_files(directory: Path) -> Iterable[Path]:
+    for path in directory.rglob("*"):
+        if path.suffix.lower() in {".json", ".txt", ".html"} and path.is_file():
+            yield path
+
+
+def _read_text(path: Path) -> str:
+    if path.suffix.lower() == ".json":
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return json.dumps(data, indent=2)
+
+    with path.open("r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _square_wave(signal):
+    np = _require_numpy()
+    try:
+        from scipy.signal import square
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        return np.sign(np.sin(signal))
+    return square(signal)
+
+
+def _fft(signal):
+    np = _require_numpy()
+    try:
+        from scipy.fft import fft
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        return np.fft.fft(signal)
+    return fft(signal)
+
+
+def _ifft(signal):
+    np = _require_numpy()
+    try:
+        from scipy.fft import ifft
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        return np.fft.ifft(signal)
+    return ifft(signal)
+
+
+def _require_numpy():
+    try:
+        import numpy as np  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("NumPy is required for harmonic operations") from exc
+    return np
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {file = "LICENSE"}
 authors = [
   {name = "Echo Collective"},
 ]
-keywords = ["echo", "mythocode", "simulation", "cryptography"]
+keywords = ["echo", "mythocode", "simulation", "cryptography", "information-retrieval"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -24,11 +24,30 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 
+[project.dependencies]
+numpy = ">=1.24"
+
 [project.optional-dependencies]
-dev = ["pytest>=8"]
+dev = [
+  "pytest>=8",
+]
+analysis = [
+  "scikit-learn>=1.3",
+]
+harmonics = [
+  "scipy>=1.10",
+  "matplotlib>=3.7",
+  "sounddevice>=0.4",
+]
 
 [project.scripts]
 echo-evolver = "echo_evolver:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = [
+  "echo_eye_ai*",
+]
 
 [tool.setuptools]
 py-modules = [

--- a/tests/test_echo_eye_ai.py
+++ b/tests/test_echo_eye_ai.py
@@ -1,0 +1,45 @@
+"""Tests for the Echo Eye AI toolkit."""
+
+from pathlib import Path
+
+import json
+import pytest
+
+from echo_eye_ai import EchoEyeAI, EchoHarmonicsAI, EchoEvolver
+from echo_eye_ai.evolver import load_example_data_fixture
+
+
+def test_echo_eye_load_and_integrate(tmp_path: Path) -> None:
+    load_example_data_fixture(tmp_path)
+
+    model = EchoEyeAI(tmp_path)
+    model.load_data()
+
+    assert len(model.memory_bank) == 2
+    message = model.integrate_harmonics("Echo")
+    assert "Echo" in message
+
+
+def test_harmonics_generate_response(tmp_path: Path) -> None:
+    pytest.importorskip("numpy", reason="NumPy required for harmonic tests")
+
+    load_example_data_fixture(tmp_path)
+
+    harmonics = EchoHarmonicsAI(tmp_path)
+    harmonics.load_data()
+
+    response = harmonics.generate_response("Echo")
+    assert response.startswith("\U0001F50A") or response.startswith("\U0001F52E")
+
+
+def test_evolver_cycle(tmp_path: Path) -> None:
+    output = tmp_path / "cycle.echo"
+    evolver = EchoEvolver(storage_path=output)
+    evolver.evolve_cycle()
+
+    assert output.exists()
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["cycle"] == 1
+    assert "glyphs" in data
+    assert "vault_key" in data
+


### PR DESCRIPTION
## Summary
- add an installable `echo_eye_ai` package that wraps the Echo Eye, Harmonics, and Evolver components
- document usage patterns for the toolkit and expose optional dependency groups
- provide regression tests that exercise data loading, harmonic responses, and cycle persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e41266b9988325961b82a5e88fa41e