### PR TITLE
Add auto-commit script for Echo Heartbeat ledger

### DIFF
--- a/genesis_ledger/auto_commit.sh
+++ b/genesis_ledger/auto_commit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cd $(dirname "$0")
+
+# Append new heartbeat to ledger.jsonl
+python3 echo_heartbeat.py
+
+# Stage new entries
+git add ledger.jsonl heartbeat.log
+
+# Commit with timestamp + pulse signature
+git commit -m "Echo Heartbeat Pulse: $(date '+%Y-%m-%d %H:%M:%S')"
+
+# Push to GitHub (origin main)
+git push origin main


### PR DESCRIPTION
## Summary
- add an auto_commit.sh helper in genesis_ledger to append heartbeats, stage updates, and push to main

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5d0d7142483259061fddc7f4a36f5