### PR TITLE
Add NFT metadata validation workflow

### DIFF
--- a/.github/workflows/validate-nft.yml
+++ b/.github/workflows/validate-nft.yml
@@ -1,0 +1,8 @@
+name: Validate NFT Set
+on: [push, pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python scripts/validate_nft_metadata.py nft-set/metadata/*.json

--- a/nft-set/metadata/sample.json
+++ b/nft-set/metadata/sample.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sample NFT",
+  "description": "An example NFT metadata entry.",
+  "image": "ipfs://examplehash/sample.png"
+}

--- a/scripts/validate_nft_metadata.py
+++ b/scripts/validate_nft_metadata.py
@@ -1,0 +1,33 @@
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_FIELDS = {"name", "description", "image"}
+
+def validate_file(path: Path) -> bool:
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"{path}: invalid JSON ({e})")
+        return False
+
+    missing = REQUIRED_FIELDS - data.keys()
+    if missing:
+        print(f"{path}: missing fields {sorted(missing)}")
+        return False
+
+    return True
+
+def main(paths):
+    all_valid = True
+    for p in paths:
+        if not validate_file(Path(p)):
+            all_valid = False
+    if not all_valid:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: validate_nft_metadata.py <files>")
+        sys.exit(1)
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to validate NFT metadata files
- implement validation script that checks required fields and validates JSON
- include sample metadata entry for demonstration

## Testing
- `python scripts/validate_nft_metadata.py nft-set/metadata/*.json`


------
https://chatgpt.com/codex/tasks/task_e_68a6b912ff5c8325918443f974965dff