### PR TITLE
Add MkDocs build session and CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs
+on:
+  push:
+    branches: ["main"]
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install nox
+      - run: nox -s docs
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# EchoGlyphNet
+
+Welcome to the EchoGlyphNet documentation.
+
+This site is built with [MkDocs](https://www.mkdocs.org/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: EchoGlyphNet Docs
+nav:
+  - Home: index.md

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,6 @@
+import nox
+
+@nox.session
+def docs(session):
+    session.install("mkdocs", "mkdocs-material")
+    session.run("mkdocs", "build")


### PR DESCRIPTION
## Summary
- add MkDocs config and simple docs
- add nox docs session and CI workflow to build and deploy docs

## Testing
- `nox -s docs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6b8f713908325893b88b3d3d7d684